### PR TITLE
Remove shoreditch as a requires

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -26,7 +26,4 @@
   <civix>
     <namespace>CRM/Api4</namespace>
   </civix>
-  <requires>
-    <ext>org.civicrm.shoreditch</ext>
-  </requires>
 </extension>


### PR DESCRIPTION
Shoreditch is not required for the api - only the explorer