### PR TITLE
Can't return any custom field but the first in a group

### DIFF
--- a/tests/phpunit/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/Action/BasicCustomFieldTest.php
@@ -67,4 +67,70 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
     $this->assertEquals('Blue', $contactFields['FavColor']);
   }
 
+  public function testWithTwoFields() {
+
+    $customGroup = CustomGroup::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('name', 'MyContactFields')
+      ->addValue('extends', 'Contact')
+      ->execute()
+      ->first();
+
+    CustomField::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('label', 'FavColor')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Text')
+      ->addValue('data_type', 'String')
+      ->execute();
+
+    CustomField::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('label', 'FavFood')
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Text')
+      ->addValue('data_type', 'String')
+      ->execute();
+
+    $contactId = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Johann')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->addValue('MyContactFields.FavColor', 'Red')
+      ->addValue('MyContactFields.FavFood', 'Cherry')
+      ->execute()
+      ->first()['id'];
+
+    $contact = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addSelect('first_name')
+      ->addSelect('MyContactFields.FavColor')
+      ->addSelect('MyContactFields.FavFood')
+      ->addWhere('id', '=', $contactId)
+      ->addWhere('MyContactFields.FavColor', '=', 'Red')
+      ->addWhere('MyContactFields.FavFood', '=', 'Cherry')
+      ->execute()
+      ->first();
+    $this->assertArrayHasKey('MyContactFields', $contact);
+    $contactFields = $contact['MyContactFields'];
+    $this->assertArrayHasKey('FavColor', $contactFields);
+    $this->assertEquals('Red', $contactFields['FavColor']);
+
+    Contact::update()
+      ->addWhere('id', '=', $contactId)
+      ->addValue('MyContactFields.FavColor', 'Blue')
+      ->execute();
+
+    $contact = Contact::get()
+      ->setCheckPermissions(FALSE)
+      ->addSelect('MyContactFields.FavColor')
+      ->addWhere('id', '=', $contactId)
+      ->execute()
+      ->first();
+
+    $contactFields = $contact['MyContactFields'];
+    $this->assertEquals('Blue', $contactFields['FavColor']);
+  }
+
 }

--- a/tests/phpunit/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/Action/BasicCustomFieldTest.php
@@ -112,7 +112,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addWhere('MyContactFields.FavFood', '=', 'Cherry')
       ->execute()
       ->first();
-    print_r($contact);
+
     $this->assertArrayHasKey('MyContactFields', $contact);
     $contactFields = $contact['MyContactFields'];
     $this->assertArrayHasKey('FavColor', $contactFields);

--- a/tests/phpunit/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/Action/BasicCustomFieldTest.php
@@ -112,6 +112,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->addWhere('MyContactFields.FavFood', '=', 'Cherry')
       ->execute()
       ->first();
+    print_r($contact);
     $this->assertArrayHasKey('MyContactFields', $contact);
     $contactFields = $contact['MyContactFields'];
     $this->assertArrayHasKey('FavColor', $contactFields);


### PR DESCRIPTION
When you make an API call and attempt to return a custom field value, the value returned will always be the value of the first custom field in the group.  E.g. given custom fields "Favorite Color", "Favorite Food", "Favorite Drink", and a contact whose corresponding values are "Red", "Cherry", "Fruit Punch", the following API call:

```php
Contact::get()
      ->setCheckPermissions(FALSE)
      ->addSelect('first_name')
      ->addSelect('MyContactFields.FavFood')
      ->addSelect('MyContactFields.FavDrink')
      ->addWhere('id', '=', $contactId)
      ->execute
```

Will return:
```
Array
(
    [id] => 1
    [first_name] => Johann
    [MyContactFields] => Array
        (
            [FavFood] => Red
            [FavDrink] => Red
            [id] => 1
        )

)
```
It returns the value of `FavColor` for all custom fields - even when that field isn't a requested field to return.

This PR is a unit test that demonstrates the problem.  I tried tracing the problem but got stuck.  I figured out that custom fields which aren't in the `custom_xx` format are joined using `addFkField()`, which returns NULL because the field name isn't a core field name.
