### PR TITLE
Fix services.xml syntax for Symfony 3

### DIFF
--- a/services.xml
+++ b/services.xml
@@ -10,8 +10,9 @@
             <argument type="service" id="dispatcher" />
         </service>
 
-        <!-- factory service is deprecated but for now we're stuck with v2.5 -->
-        <service id="schema_map" class="Civi\Api4\Service\Schema\SchemaMap" factory-service="schema_map_builder" factory-method="build"/>
+        <service id="schema_map" class="Civi\Api4\Service\Schema\SchemaMap">
+          <factory service="schema_map_builder" method="build"/>
+        </service>
 
         <service id="joiner" class="Civi\Api4\Service\Schema\Joiner">
             <argument type="service" id="schema_map"/>


### PR DESCRIPTION
On Drupal8, when viewing a contact, I was getting this error:

```
Symfony\Component\DependencyInjection\Exception\InvalidArgumentException:
Unable to parse file "/var/aegir/platforms/civicrm-d8/vendor/civicrm/civicrm-core/ext/api4/services.xml". in Symfony\Component\DependencyInjection\Loader\XmlFileLoader->parseFileToDOM()
(line 386 of /var/aegir/platforms/civicrm-d8/vendor/civicrm/civicrm-core/vendor/symfony/dependency-injection/Loader/XmlFileLoader.php).
```

Digging deeper, the error was:

```
[ERROR 1866] Element '{http://symfony.com/schema/dic/services}service', attribute 'factory-service': The attribute  'factory-service' is not allowed. (in /var/aegir/platforms/civicrm-d8/ - line 14, column 0)                                                                                                        
```

With random googling, I found:

* https://github.com/isometriks/GoogleApiBundle/pull/3
* https://github.com/symfony/symfony/blob/2.7/UPGRADE-3.0.md#dependencyinjection

That said, CiviCRM still allows building with Symfony 2, so this might require upstream to bump up the version requirements?