### PR TITLE
Simplify ArrayRetrieval::processArrayData and MockArrayEntity::Get. 

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -373,8 +373,10 @@ abstract class AbstractAction implements \ArrayAccess {
   /**
    * Write a bao object as part of a create/update action.
    *
-   * @param $params
+   * @param array $params
+   *   The record to write to the DB.
    * @return array
+   *   The record after being written to the DB (e.g. including newly assigned "id").
    * @throws \API_Exception
    */
   protected function writeObject($params) {

--- a/Civi/Api4/Generic/ArrayRetrievalTrait.php
+++ b/Civi/Api4/Generic/ArrayRetrievalTrait.php
@@ -11,15 +11,17 @@ use Civi\API\Exception\NotImplementedException;
 trait ArrayRetrievalTrait {
 
   /**
-   * @param $values
-   * @param Result $result
+   * @param array $values
+   *   List of all rows
+   * @return array
+   *   Filtered list of rows
    */
-  protected function processArrayData($values, Result $result) {
+  protected function processArrayData($values) {
     $values = $this->filterArray($values);
     $values = $this->sortArray($values);
     $values = $this->selectArray($values);
     $values = $this->limitArray($values);
-    $result->exchangeArray($values);
+    return $values;
   }
 
   /**

--- a/tests/phpunit/Mock/Api4/Action/MockArrayEntity/Get.php
+++ b/tests/phpunit/Mock/Api4/Action/MockArrayEntity/Get.php
@@ -11,7 +11,7 @@ use \Civi\Api4\Action\Get as DefaultGet;
 class Get extends DefaultGet {
   use ArrayRetrievalTrait;
 
-  public function _run(Result $result) {
+  public function getObjects() {
     $data = [
       [
         'field1' => 1,
@@ -52,7 +52,7 @@ class Get extends DefaultGet {
         'field6' => 0,
       ],
     ];
-    $this->processArrayData($data, $result);
+    return $this->processArrayData($data);
   }
 
 }


### PR DESCRIPTION
The contract for subclasses of `Get` was just updated to add `getObjects()`, which is a more narrow+mixable target for overriding than `_run()`. This switches to the new function name propagates some simplifications in the affiliated `processArrayData()`.

