### PR TITLE
Less restrictive access to Entity::get()

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -12,12 +12,6 @@ use Civi\Api4\Utils\ReflectionUtils;
  */
 class GetActions extends BasicGetAction {
 
-  /**
-   * Override default to allow open access
-   * @inheritDoc
-   */
-  protected $checkPermissions = FALSE;
-
   private $_actions = [];
 
   private $_actionsToGet = [];

--- a/Civi/Api4/Entity.php
+++ b/Civi/Api4/Entity.php
@@ -34,7 +34,9 @@ class Entity extends Generic\AbstractEntity {
    * @return array
    */
   public static function permissions() {
-    return [];
+    return [
+      'default' => ['access CiviCRM']
+    ];
   }
 
 }

--- a/Civi/Api4/Generic/DAOGetFieldsAction.php
+++ b/Civi/Api4/Generic/DAOGetFieldsAction.php
@@ -24,12 +24,6 @@ use Civi\Api4\Generic\Result;
 class DAOGetFieldsAction extends AbstractAction {
 
   /**
-   * Override default to allow open access
-   * @inheritDoc
-   */
-  protected $checkPermissions = FALSE;
-
-  /**
    * Include custom fields for this entity, or only core fields?
    *
    * @var bool

--- a/Civi/Api4/Service/Schema/SchemaMapBuilder.php
+++ b/Civi/Api4/Service/Schema/SchemaMapBuilder.php
@@ -27,7 +27,7 @@ class SchemaMapBuilder {
    */
   public function __construct(EventDispatcherInterface $dispatcher) {
     $this->dispatcher = $dispatcher;
-    $this->apiEntities = array_keys((array) Entity::get()->addSelect('name')->execute()->indexBy('name'));
+    $this->apiEntities = array_keys((array) Entity::get()->setCheckPermissions(FALSE)->addSelect('name')->execute()->indexBy('name'));
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/civicrm/org.civicrm.contactlayout/issues/52

`Entity::get()` was mistakenly requiring `administer CiviCRM` when it should be `access CiviCRM` per other "meta" actions. Also permissions do not need checking when `Entity::get()` is being called internally.