### PR TITLE
Simplify and clarify the meaning of "required" fields

### DIFF
--- a/Civi/Api4/Event/Subscriber/PreCreationSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PreCreationSubscriber.php
@@ -45,9 +45,6 @@ abstract class PreCreationSubscriber extends AbstractPrepareSubscriber {
    * @param DAOCreateAction $request
    */
   protected function addDefaultCreationValues(DAOCreateAction $request) {
-    if (NULL === $request->getValue('is_active')) {
-      $request->addValue('is_active', 1);
-    }
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/CustomValueSpecProvider.php
@@ -6,37 +6,22 @@ use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
 
 class CustomValueSpecProvider implements SpecProviderInterface {
+
   /**
    * @inheritDoc
    */
   public function modifySpec(RequestSpec $spec) {
     $action = $spec->getAction();
-    $extraFields = [
-      'id' => [
-        'required' => ($action === 'update'),
-        'title' => ts('Custom Table Unique ID'),
-        'fk_entity' => NULL,
-      ],
-      'entity_id' => [
-        'required' => ($action === 'create'),
-        'title' => ts('Entity ID'),
-        'fk_entity' => 'Contact',
-      ],
-    ];
-    foreach ($extraFields as $name => $field) {
-      // Do not add id field on create action
-      if ('create' === $action && 'id' === $name) {
-        continue;
-      }
-      $fieldSpec = new FieldSpec($name, $spec->getEntity(), 'Integer');
-      $fieldSpec->setTitle($field['title']);
-      $fieldSpec->setRequired($field['required']);
-      if (!empty($field['fk_entity'])) {
-        $fieldSpec->setFkEntity($field['fk_entity']);
-      }
-
-      $spec->addFieldSpec($fieldSpec);
+    if ($action !== 'create') {
+      $idField = new FieldSpec('id', $spec->getEntity(), 'Integer');
+      $idField->setTitle(ts('Custom Value ID'));
+      $spec->addFieldSpec($idField);
     }
+    $entityField = new FieldSpec('entity_id', $spec->getEntity(), 'Integer');
+    $entityField->setTitle(ts('Entity ID'));
+    $entityField->setRequired($action === 'create');
+    $entityField->setFkEntity('Contact');
+    $spec->addFieldSpec($entityField);
   }
 
   /**

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -46,7 +46,6 @@ class SpecFormatter {
       }
       $field->setCustomFieldId(ArrayHelper::value('id', $data));
       $field->setCustomGroupName($data['custom_group']['name']);
-      $field->setRequired((bool) ArrayHelper::value('is_required', $data, FALSE));
       $field->setTitle(ArrayHelper::value('label', $data));
       $field->setOptions(self::customFieldHasOptions($data));
       if (\CRM_Core_BAO_CustomField::isSerialized($data)) {

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -73,6 +73,9 @@ class SpecGatherer {
       if ($DAOField['name'] == 'id' && $action == 'create') {
         continue;
       }
+      if ($action !== 'create') {
+        $DAOField['required'] = FALSE;
+      }
       $field = SpecFormatter::arrayToField($DAOField, $entity);
       $specification->addFieldSpec($field);
     }
@@ -86,7 +89,7 @@ class SpecGatherer {
     $extends = ($entity == 'Contact') ? ['Contact', 'Individual', 'Organization', 'Household'] : [$entity];
     $customFields = CustomField::get()
       ->addWhere('custom_group.extends', 'IN', $extends)
-      ->setSelect(['custom_group.name', 'custom_group_id', 'name', 'label', 'data_type', 'html_type', 'is_required', 'is_searchable', 'is_search_range', 'weight', 'is_active', 'is_view', 'option_group_id', 'default_value'])
+      ->setSelect(['custom_group.name', 'custom_group_id', 'name', 'label', 'data_type', 'html_type', 'is_searchable', 'is_search_range', 'weight', 'is_active', 'is_view', 'option_group_id', 'default_value'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {
@@ -102,7 +105,7 @@ class SpecGatherer {
   private function getCustomGroupFields($customGroup, RequestSpec $specification) {
     $customFields = CustomField::get()
       ->addWhere('custom_group.name', '=', $customGroup)
-      ->setSelect(['custom_group.name', 'custom_group_id', 'name', 'label', 'data_type', 'html_type', 'is_required', 'is_searchable', 'is_search_range', 'weight', 'is_active', 'is_view', 'option_group_id', 'default_value', 'custom_group.table_name', 'column_name'])
+      ->setSelect(['custom_group.name', 'custom_group_id', 'name', 'label', 'data_type', 'html_type', 'is_searchable', 'is_search_range', 'weight', 'is_active', 'is_view', 'option_group_id', 'default_value', 'custom_group.table_name', 'column_name'])
       ->execute();
 
     foreach ($customFields as $fieldArray) {

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -76,6 +76,9 @@ class SpecGatherer {
       if ($action !== 'create' || isset($DAOField['default'])) {
         $DAOField['required'] = FALSE;
       }
+      if ($DAOField['name'] == 'is_active' && empty($DAOField['default'])) {
+        $DAOField['default'] = '1';
+      }
       $field = SpecFormatter::arrayToField($DAOField, $entity);
       $specification->addFieldSpec($field);
     }

--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -73,7 +73,7 @@ class SpecGatherer {
       if ($DAOField['name'] == 'id' && $action == 'create') {
         continue;
       }
-      if ($action !== 'create') {
+      if ($action !== 'create' || isset($DAOField['default'])) {
         $DAOField['required'] = FALSE;
       }
       $field = SpecFormatter::arrayToField($DAOField, $entity);

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -140,7 +140,7 @@
 
     $scope.formatSelect2Item = function(row) {
       return _.escape(row.text) +
-        (isFieldRequired(row) ? '<span class="crm-marker"> *</span>' : '') +
+        (row.required ? '<span class="crm-marker"> *</span>' : '') +
         (row.description ? '<div class="crm-select2-row-description"><p>' + _.escape(row.description) + '</p></div>' : '');
     };
 
@@ -152,10 +152,6 @@
       var specialParams = ['select', 'fields', 'action', 'where', 'values', 'orderBy', 'chain'];
       return _.contains(specialParams, name);
     };
-
-    function isFieldRequired(field) {
-      return field.required && !field.default_value;
-    }
 
     function getEntity(entityName) {
       return _.findWhere(schema, {name: entityName || $scope.entity});
@@ -298,7 +294,7 @@
 
     function defaultValues(defaultVal) {
       _.each($scope.fields, function(field) {
-        if (isFieldRequired(field)) {
+        if (field.required) {
           defaultVal.push([field.id, '']);
         }
       });

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -140,7 +140,7 @@
 
     $scope.formatSelect2Item = function(row) {
       return _.escape(row.text) +
-        (isFieldRequiredForCreate(row) ? '<span class="crm-marker"> *</span>' : '') +
+        (isFieldRequired(row) ? '<span class="crm-marker"> *</span>' : '') +
         (row.description ? '<div class="crm-select2-row-description"><p>' + _.escape(row.description) + '</p></div>' : '');
     };
 
@@ -153,7 +153,7 @@
       return _.contains(specialParams, name);
     };
 
-    function isFieldRequiredForCreate(field) {
+    function isFieldRequired(field) {
       return field.required && !field.default_value;
     }
 
@@ -254,6 +254,9 @@
             if (name == 'limit') {
               defaultVal = 25;
             }
+            if (name === 'values') {
+              defaultVal = defaultValues(defaultVal);
+            }
             $scope.$bindToRoute({
               expr: 'params["' + name + '"]',
               param: name,
@@ -291,6 +294,15 @@
         $scope.availableParams = actionInfo.params;
       }
       writeCode();
+    }
+
+    function defaultValues(defaultVal) {
+      _.each($scope.fields, function(field) {
+        if (isFieldRequired(field)) {
+          defaultVal.push([field.id, '']);
+        }
+      });
+      return defaultVal;
     }
 
     function stringify(value, trim) {

--- a/tests/phpunit/Action/CustomValueTest.php
+++ b/tests/phpunit/Action/CustomValueTest.php
@@ -62,7 +62,7 @@ class CustomValueTest extends BaseCustomValueTest {
       ],
       [
         'name' => 'id',
-        'title' => ts('Custom Table Unique ID'),
+        'title' => ts('Custom Value ID'),
         'entity' => "Custom_$group",
         'data_type' => 'Integer',
         'fk_entity' => NULL,


### PR DESCRIPTION
Is it just me, or has the meaning of "required" in the api been more complicated than it needs to be?

In api3, "required" means something like "you must supply this param, but only if `$action == 'create'` and `api_required != 0`. And "not required" means "you don't need to supply this unless `$action == 'create'` and `api_required == 1`". The `id` field is magically required for `update()` and `delete()` (unless you do some magic with `match_mandatory`) but not `create()`.

In api4 we've already gone a long way toward simplifying this by teasing out the difference between *fields* and *params*.  Each action is able to specify which *params* are required, e.g. `create()` requires the `values` param (a collection of fields), `update()` requires `where` and `values` But we're still a bit messy on the topic of required field in the `values` param of those various actions.

- Fields marked "required" in the schema are only *actually* required for the "create" action. However they still *appear* required if you inspect `getFields` for other actions but the requirement is ignored.
- Required fields are only required if they don't have a default_value in the schema and we do some magic to skip those from validation.
- If you wanted to require fields for other actions, e.g. if your entity *must* have some field specified for its `update()` action, you're currently out of luck - the api4 validator doesn't even run on `update()` actions.

This PR:

- Alters `getFields()`:
  - Removes *required* from all custom fields - they are never required in the api layer.
  - Removes *required* from all core DAO fields with a `default_value` in the schema.
  - Removes *required* from all core DAO fields when `action` is not "create".
  - Removes *required* from the `id` field when action is `update` in the CustomValue api (this was a mistake - api4 doesn't update by id it uses a batch process).
- Alters the Api Explorer:
  - Auto-selects required fields in the "values" param.
- TODO:
  - Run validation on all actions with a "values" param, not just `create`.
  - Resolve inconsistency with batch actions (`update`, `replace`, `delete`). Should the "id" field be returned by `getFields` for these actions? It can be used for selecting items but cannot be used for updating them. I'm thinking exclude it and rely on `getFields` for the `get()` action for the get-related clauses.