### PR TITLE
Use native Promise instead of jQuery deferred

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -345,7 +345,7 @@
         if (index || index === 0) {
           code.javascript += ', ' + JSON.stringify(index);
         }
-        code.javascript += ").done(function(" + results + ") {\n  // do something with " + results + " array\n});";
+        code.javascript += ").then(function(" + results + ") {\n  // do something with " + results + " array\n}, function(failure) {\n  // handle failure\n});";
 
         // Write php code
         if (entity.substr(0, 7) !== 'Custom_') {

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,7 @@
   <version>4.3.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.13</ver>
   </compatibility>
   <comments>This extension does nothing on its own. Install it if other extensions require you to do so.</comments>
   <classloader>

--- a/js/api4.js
+++ b/js/api4.js
@@ -12,33 +12,32 @@
   }
 
   CRM.api4 = function(entity, action, params, index) {
-    var deferred = $.Deferred();
-    if (typeof entity === 'string') {
-      $.post(CRM.url('civicrm/ajax/api4/' + entity + '/' + action), {
-          params: JSON.stringify(params),
-          index: index
-        })
-        .done(function (data) {
-          deferred.resolve(arrayObject(data));
-        })
-        .fail(function (data) {
-          deferred.reject(data.responseJSON);
-        });
-    } else {
-      $.post(CRM.url('civicrm/ajax/api4'), {
-          calls: JSON.stringify(entity)
-        })
-        .done(function(data) {
-          _.each(data, function(item, key) {
-            data[key] = arrayObject(item);
+    return new Promise(function(resolve, reject) {
+      if (typeof entity === 'string') {
+        $.post(CRM.url('civicrm/ajax/api4/' + entity + '/' + action), {
+            params: JSON.stringify(params),
+            index: index
+          })
+          .done(function (data) {
+            resolve(arrayObject(data));
+          })
+          .fail(function (data) {
+            reject(data.responseJSON);
           });
-          deferred.resolve(data);
-        })
-        .fail(function (data) {
-          deferred.reject(data.responseJSON);
-        });
-    }
-
-    return deferred;
+      } else {
+        $.post(CRM.url('civicrm/ajax/api4'), {
+            calls: JSON.stringify(entity)
+          })
+          .done(function(data) {
+            _.each(data, function(item, key) {
+              data[key] = arrayObject(item);
+            });
+            resolve(data);
+          })
+          .fail(function (data) {
+            reject(data.responseJSON);
+          });
+      }
+    });
   };
 })(CRM.$, CRM._);

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ $entity = $result->entity; // "Contact"
 We can do the something very similar in javascript thanks to js arrays also being objects:
 
 ```javascript
-CRM.api4('Contact', 'get', params).done(function(result) {
+CRM.api4('Contact', 'get', params).then(function(result) {
   // you can loop through the results
   result.forEach(function(contact, n) {});
 


### PR DESCRIPTION
Before
-----
`CRM.api4()` returned a jQuery deferred object which is "thenable" but not Promise/A+ compliant.

After
-------
`CRM.api4()` returns a native Javascript Promise.

Notes
------
Anyone using the `then` method previously will not notice the difference. Angular `crmApi4` is unaffected.