### PR TITLE
Optimize update for a single record

### DIFF
--- a/Civi/Api4/Contact.php
+++ b/Civi/Api4/Contact.php
@@ -21,12 +21,4 @@ class Contact extends Generic\DAOEntity {
     return new Action\Contact\Create(__CLASS__, __FUNCTION__);
   }
 
-  /**
-   * @return \Civi\Api4\Generic\DAOUpdateAction
-   */
-  public static function update() {
-    // For some reason the contact bao requires this for updating
-    return new Generic\DAOUpdateAction(__CLASS__, __FUNCTION__, ['id', 'contact_type']);
-  }
-
 }

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -13,13 +13,42 @@ class DAOUpdateAction extends AbstractUpdateAction {
   use Traits\DAOActionTrait;
 
   /**
+   * Criteria for selecting items to update.
+   *
+   * Required if no id is supplied in values.
+   *
+   * @var array
+   */
+  protected $where = [];
+
+  /**
    * @inheritDoc
    */
   public function _run(Result $result) {
+    // Add ID from values to WHERE clause and check for mismatch
     if (!empty($this->values['id'])) {
-      throw new \Exception("Cannot update the id of an existing " . $this->getEntityName() . '.');
+      $wheres = array_column($this->where, NULL, 0);
+      if (!isset($wheres['id'])) {
+        $this->addWhere('id', '=', $this->values['id']);
+      }
+      elseif (!($wheres['id'][1] === '=' && $wheres['id'][2] == $this->values['id'])) {
+        throw new \Exception("Cannot update the id of an existing " . $this->getEntityName() . '.');
+      }
     }
 
+    // Require WHERE if we didn't get an ID from values
+    if (!$this->where) {
+      throw new \API_Exception('Parameter "where" is required unless an id is supplied in values.');
+    }
+
+    // Update a single record by ID
+    if (count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
+      $this->values['id'] = $this->where[0][2];
+      $result->exchangeArray($this->writeObjects([$this->values]));
+      return;
+    }
+
+    // Batch update 1 or more records based on WHERE clause
     $items = $this->getObjects();
     foreach ($items as &$item) {
       $item = $this->values + $item;

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -41,8 +41,8 @@ class DAOUpdateAction extends AbstractUpdateAction {
       throw new \API_Exception('Parameter "where" is required unless an id is supplied in values.');
     }
 
-    // Update a single record by ID
-    if (count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
+    // Update a single record by ID unless select requires more than id
+    if ($this->getSelect() === ['id'] && count($this->where) === 1 && $this->where[0][0] === 'id' && $this->where[0][1] === '=' && !empty($this->where[0][2])) {
       $this->values['id'] = $this->where[0][2];
       $result->exchangeArray($this->writeObjects([$this->values]));
       return;

--- a/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
+++ b/Civi/Api4/Generic/Traits/CustomValueActionTrait.php
@@ -12,7 +12,7 @@ use Civi\Api4\Utils\CoreUtil;
  */
 trait CustomValueActionTrait {
 
-  function __construct($customGroup, $actionName) {
+  public function __construct($customGroup, $actionName) {
     $this->customGroup = $customGroup;
     parent::__construct('CustomValue', $actionName, ['id', 'entity_id']);
   }
@@ -36,8 +36,17 @@ trait CustomValueActionTrait {
    */
   protected function writeObjects($items) {
     $result = [];
+    $fields = $this->getEntityFields();
     foreach ($items as $item) {
-      FormattingUtil::formatWriteParams($item, $this->getEntityName(), $this->getEntityFields());
+      FormattingUtil::formatWriteParams($item, $this->getEntityName(), $fields);
+
+      // Convert field names to custom_xx format
+      foreach ($fields as $name => $field) {
+        if (!empty($field['custom_field_id']) && isset($item[$name])) {
+          $item['custom_' . $field['custom_field_id']] = $item[$name];
+          unset($item[$name]);
+        }
+      }
 
       $result[] = \CRM_Core_BAO_CustomValueTable::setValues($item);
     }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -77,6 +77,11 @@ trait DAOActionTrait {
       FormattingUtil::formatWriteParams($item, $this->getEntityName(), $this->getEntityFields());
       $this->formatCustomParams($item, $entityId);
 
+      // For some reason the contact bao requires this
+      if ($entityId && $this->getEntityName() == 'Contact') {
+        $item['contact_id'] = $entityId;
+      }
+
       if (method_exists($baoName, $method)) {
         $createResult = $baoName::$method($item);
       }

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -48,12 +48,12 @@ trait DAOActionTrait {
   }
 
   /**
-   * Write a bao object as part of a create/update action.
+   * Write bao objects as part of a create/update action.
    *
    * @param array $items
-   *   The record to write to the DB.
+   *   The records to write to the DB.
    * @return array
-   *   The record after being written to the DB (e.g. including newly assigned "id").
+   *   The records after being written to the DB (e.g. including newly assigned "id").
    * @throws \API_Exception
    */
   protected function writeObjects($items) {
@@ -77,10 +77,6 @@ trait DAOActionTrait {
       FormattingUtil::formatWriteParams($item, $this->getEntityName(), $this->getEntityFields());
       $this->formatCustomParams($item, $entityId);
 
-      // For some reason the contact bao requires this
-      if ($entityId && $this->getEntityName() == 'Contact') {
-        $item['contact_id'] = $entityId;
-      }
       if (method_exists($baoName, $method)) {
         $createResult = $baoName::$method($item);
       }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -46,16 +46,6 @@ class FormattingUtil {
         $params[$name] = 'null';
       }
 
-      if (strstr($entity, 'Custom_')) {
-        if ($name == 'entity_id') {
-          $params['entityID'] = $params['entity_id'];
-          unset($params['entity_id']);
-        }
-        elseif (!empty($field['custom_field_id'])) {
-          $params['custom_' . $field['custom_field_id']] = $params[$name];
-          unset($params[$name]);
-        }
-      }
     }
   }
 

--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,7 @@
   <version>4.3.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.13</ver>
+    <ver>5.14</ver>
   </compatibility>
   <comments>This extension does nothing on its own. Install it if other extensions require you to do so.</comments>
   <classloader>

--- a/tests/phpunit/Action/CustomValueTest.php
+++ b/tests/phpunit/Action/CustomValueTest.php
@@ -22,6 +22,7 @@ class CustomValueTest extends BaseCustomValueTest {
 
     $group = uniqid('groupc');
     $colorField = uniqid('colorc');
+    $textField = uniqid('txt');
 
     $customGroup = CustomGroup::create()
       ->setCheckPermissions(FALSE)
@@ -40,6 +41,14 @@ class CustomValueTest extends BaseCustomValueTest {
       ->addValue('data_type', 'String')
       ->execute();
 
+    CustomField::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('label', $textField)
+      ->addValue('custom_group_id', $customGroup['id'])
+      ->addValue('html_type', 'Text')
+      ->addValue('data_type', 'String')
+      ->execute();
+
     $this->contactID = Contact::create()
       ->setCheckPermissions(FALSE)
       ->addValue('first_name', 'Johann')
@@ -55,7 +64,16 @@ class CustomValueTest extends BaseCustomValueTest {
         'custom_field_id' => 1,
         'custom_group' => $group,
         'name' => $colorField,
-        'title' => ts($colorField),
+        'title' => $colorField,
+        'entity' => "Custom_$group",
+        'data_type' => 'String',
+        'fk_entity' => NULL,
+      ],
+      [
+        'custom_field_id' => 2,
+        'custom_group' => $group,
+        'name' => $textField,
+        'title' => $textField,
         'entity' => "Custom_$group",
         'data_type' => 'String',
         'fk_entity' => NULL,

--- a/tests/phpunit/Action/UpdateContactTest.php
+++ b/tests/phpunit/Action/UpdateContactTest.php
@@ -12,7 +12,7 @@ use Civi\Test\Api4\UnitTestCase;
  */
 class UpdateContactTest extends UnitTestCase {
 
-  public function testUpdateWillWork() {
+  public function testUpdateWithIdInWhere() {
     $contactId = Contact::create()
       ->setCheckPermissions(FALSE)
       ->addValue('first_name', 'Johann')
@@ -29,6 +29,26 @@ class UpdateContactTest extends UnitTestCase {
       ->first();
     $this->assertEquals('Testy', $contact['first_name']);
     $this->assertEquals('Tester', $contact['last_name']);
+  }
+
+  public function testUpdateWithIdInValues() {
+    $contactId = Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('first_name', 'Bobby')
+      ->addValue('last_name', 'Tester')
+      ->addValue('contact_type', 'Individual')
+      ->execute()
+      ->first()['id'];
+
+    $contact = Contact::update()
+      ->setCheckPermissions(FALSE)
+      ->addValue('id', $contactId)
+      ->addValue('first_name', 'Billy')
+      ->execute();
+    $this->assertCount(1, $contact);
+    $this->assertEquals($contactId, $contact[0]['id']);
+    $this->assertEquals('Billy', $contact[0]['first_name']);
+    $this->assertEquals('Tester', $contact[0]['last_name']);
   }
 
 }


### PR DESCRIPTION
This PR does 3 things to the `update` action for DAO-based entities:

1. When you wish to update one record by ID, allows you to skip adding ID to the WHERE clause and instead add it to `$values` (more like api3 style).
2. Optimize the update process to skip fetching a single record by id.
3. Get rid of some cruft related to the contact entity which is being fixed upstream.

Also fixes some undefined index issues in the CustomValue api.