### PR TITLE
Allow Result class to be extended

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -3,7 +3,6 @@ namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Kernel;
-use Civi\Api4\Generic\Result;
 use Civi\Api4\Utils\ReflectionUtils;
 
 /**
@@ -172,10 +171,10 @@ abstract class AbstractAction implements \ArrayAccess {
    * At this point all the params have been sent in and we initiate the api call & return the result.
    * This is basically the outer wrapper for api v4.
    *
-   * @return Result|array
+   * @return \Civi\Api4\Generic\Result
    * @throws UnauthorizedException
    */
-  final public function execute() {
+  public function execute() {
     /** @var Kernel $kernel */
     $kernel = \Civi::service('civi_api_kernel');
 
@@ -276,7 +275,7 @@ abstract class AbstractAction implements \ArrayAccess {
     if ($offset == 'check_permissions') {
       return $this->checkPermissions;
     }
-    if (isset ($this->thisArrayStorage[$offset])) {
+    if (isset($this->thisArrayStorage[$offset])) {
       return $this->thisArrayStorage[$offset];
     }
     return $val;

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\Api4\Generic\Result;
-
 /**
  * Given a set of records, will appropriately update the database.
  *
@@ -34,6 +32,13 @@ class BasicReplaceAction extends AbstractBatchAction {
    * @var bool
    */
   protected $reload = FALSE;
+
+  /**
+   * @return \Civi\Api4\Result\ReplaceResult
+   */
+  public function execute() {
+    return parent::execute();
+  }
 
   /**
    * @inheritDoc
@@ -70,7 +75,6 @@ class BasicReplaceAction extends AbstractBatchAction {
       }
     }
 
-    $result->deleted = [];
     if ($toDelete) {
       $result->deleted = (array) civicrm_api4($this->getEntityName(), 'delete', [
         'where' => [[$idField, 'IN', array_keys($toDelete)]],

--- a/Civi/Api4/Provider/ActionObjectProvider.php
+++ b/Civi/Api4/Provider/ActionObjectProvider.php
@@ -32,6 +32,7 @@ use Civi\API\Provider\ProviderInterface;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\API\Events;
 use Civi\Api4\Generic\Result;
+use Civi\Api4\Utils\ReflectionUtils;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -70,10 +71,14 @@ class ActionObjectProvider implements EventSubscriberInterface, ProviderInterfac
    *
    * @param AbstractAction $action
    *
-   * @return array|mixed
+   * @return Result
    */
   public function invoke($action) {
-    $result = new Result();
+    // Load result class based on @return annotation in the execute() method.
+    $reflection = new \ReflectionClass($action);
+    $doc = ReflectionUtils::getCodeDocs($reflection->getMethod('execute'), 'Method');
+    $resultClass = \CRM_Utils_Array::value('return', $doc, '\\Civi\\Api4\\Generic\\Result');
+    $result = new $resultClass();
     $result->action = $action->getActionName();
     $result->entity = $action->getEntityName();
     $action->_run($result);

--- a/Civi/Api4/Result/ReplaceResult.php
+++ b/Civi/Api4/Result/ReplaceResult.php
@@ -1,0 +1,10 @@
+<?php
+namespace Civi\Api4\Result;
+
+class ReplaceResult extends \Civi\Api4\Generic\Result {
+  /**
+   * @var array
+   */
+  public $deleted = [];
+
+}

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -429,8 +429,8 @@
     function formatMeta(resp) {
       var ret = '';
       _.each(resp, function(val, key) {
-        if (val !== Object(val)) {
-          ret += (ret.length ? ', ' : '') + key + ': ' + val;
+        if (key !== 'values' && !_.isPlainObject(val) && !_.isFunction(val)) {
+          ret += (ret.length ? ', ' : '') + key + ': ' + (_.isArray(val) ? '[' + val + ']' : val);
         }
       });
       return prettyPrintOne(ret);


### PR DESCRIPTION
Uses annotations to load the correct Result class for each Action.
This allows certain actions to add extra properties to their Result, and have it still work well with IDEs and the Api Explorer.