### PR TITLE
Explorer - don't parse date strings to js objects

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -227,7 +227,9 @@
         return input;
       }
       try {
-        return input === '>' ? '>' : jsyaml.safeLoad(input);
+        var output = (input === '>') ? '>' : jsyaml.safeLoad(input);
+        // We don't want dates parsed to js objects
+        return _.isDate(output) ? input : output;
       } catch (e) {
         return input;
       }


### PR DESCRIPTION
Fixes a bug caused by `parseYaml` - we don't actually want to deal with date objects in the api explorer.