### PR TITLE
More thorough padding of getFields results

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -66,6 +66,7 @@ class BasicGetFieldsAction extends BasicGetAction {
       if (!$this->loadOptions) {
         $field['options'] = (bool) $field['options'];
       }
+      $field += array_fill_keys(array_column($this->fields(), 'name'), NULL);
     }
   }
 


### PR DESCRIPTION
In keeping with the new standard of returning all fields even if they are null, let's do that for metadata as well.