### PR TITLE
Standardize delete results to be nested arrays

### DIFF
--- a/Civi/Api4/Generic/DAODeleteAction.php
+++ b/Civi/Api4/Generic/DAODeleteAction.php
@@ -39,7 +39,7 @@ class DAODeleteAction extends AbstractBatchAction {
         $args = [$item['id']];
         $bao = call_user_func_array([$baoName, 'del'], $args);
         if ($bao !== FALSE) {
-          $ids[] = $item['id'];
+          $ids[] = ['id' => $item['id']];
         }
         else {
           throw new \API_Exception("Could not delete {$this->getEntityName()} id {$item['id']}");
@@ -53,7 +53,7 @@ class DAODeleteAction extends AbstractBatchAction {
         // delete it
         $action_result = $bao->delete();
         if ($action_result) {
-          $ids[] = $item['id'];
+          $ids[] = ['id' => $item['id']];
         }
         else {
           throw new \API_Exception("Could not delete {$this->getEntityName()} id {$item['id']}");

--- a/tests/phpunit/Action/ReplaceTest.php
+++ b/tests/phpunit/Action/ReplaceTest.php
@@ -64,7 +64,7 @@ class ReplaceTest extends UnitTestCase {
     // Should have saved 2 records
     $this->assertEquals(2, $replaced->count());
     // Should have deleted email2
-    $this->assertEquals([$e2], $replaced->deleted);
+    $this->assertEquals([['id' => $e2]], $replaced->deleted);
     // Verify contact now has the new email records
     $results = Email::get()
       ->addWhere('contact_id', '=', $cid1)

--- a/tests/phpunit/Entity/ConformanceTest.php
+++ b/tests/phpunit/Entity/ConformanceTest.php
@@ -229,7 +229,7 @@ class ConformanceTest extends UnitTestCase {
       ->execute();
 
     // should get back an array of deleted id
-    $this->assertEquals([$id], (array) $deleteResult);
+    $this->assertEquals([['id' => $id]], (array) $deleteResult);
   }
 
   /**

--- a/tests/phpunit/Entity/ParticipantTest.php
+++ b/tests/phpunit/Entity/ParticipantTest.php
@@ -187,7 +187,7 @@ class ParticipantTest extends UnitTestCase {
       ->setCheckPermissions(FALSE)
       ->execute();
     $expectedDeletes = [2, 7, 12, 17];
-    $this->assertEquals($expectedDeletes, (array) $deleteResult,
+    $this->assertEquals($expectedDeletes, array_column((array) $deleteResult, 'id'),
       "didn't delete every second record as expected");
 
     $sqlCount = $this->getRowCount('civicrm_participant');


### PR DESCRIPTION
Shore up the oddball return format to be consistent with other actions.