### PR TITLE
ApiExplorer: fallback when field entity not declaired

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -660,7 +660,7 @@
               $el.crmEntityRef({entity: field.fk_entity, select:{multiple: multi}});
             } else if (field.options) {
               $el.addClass('loading').attr('placeholder', ts('- select -')).crmSelect2({multiple: multi, data: [{id: '', text: ''}]});
-              loadFieldOptions(field.entity).then(function(data) {
+              loadFieldOptions(field.entity || entity).then(function(data) {
                 var options = [];
                 _.each(_.findWhere(data, {name: field.name}).options, function(val, key) {
                   options.push({id: key, text: val});


### PR DESCRIPTION
Sometimes getfields doesn't return the entity with the field, e.g. the Settings entity does not.