### PR TITLE
Throw error when update fails

### DIFF
--- a/Civi/Api4/Generic/AbstractQueryAction.php
+++ b/Civi/Api4/Generic/AbstractQueryAction.php
@@ -119,7 +119,11 @@ abstract class AbstractQueryAction extends AbstractAction {
     }
     if (in_array($whereClause[0], ['AND', 'OR', 'NOT'])) {
       $op = array_shift($whereClause);
-      return '(' . $this->whereClauseToString($whereClause, $op) . ')';
+      if ($op == 'NOT') {
+        $output = 'NOT ';
+        $op = 'AND';
+      }
+      return $output . '(' . $this->whereClauseToString($whereClause, $op) . ')';
     }
     elseif (isset($whereClause[1]) && in_array($whereClause[1], \CRM_Core_DAO::acceptedSQLOperators())) {
       $output = $whereClause[0] . ' ' . $whereClause[1] . ' ';

--- a/Civi/Api4/Generic/BasicUpdateAction.php
+++ b/Civi/Api4/Generic/BasicUpdateAction.php
@@ -38,10 +38,16 @@ class BasicUpdateAction extends AbstractUpdateAction {
    * We expect to get the same format back.
    *
    * @param \Civi\Api4\Generic\Result $result
+   * @throws \API_Exception
+   * @throws \Civi\API\Exception\NotImplementedException
    */
   public function _run(Result $result) {
     foreach ($this->getBatchRecords() as $item) {
       $result[] = $this->writeRecord($this->values + $item);
+    }
+
+    if (!$result->count()) {
+      throw new \API_Exception('Cannot ' . $this->getActionName() . ' ' . $this->getEntityName() . ', no records found with ' . $this->whereClauseToString());
     }
   }
 

--- a/Civi/Api4/Generic/DAOCreateAction.php
+++ b/Civi/Api4/Generic/DAOCreateAction.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\Api4\Generic\Result;
-
 /**
  * Create a new object from supplied values.
  *

--- a/Civi/Api4/Generic/DAOGetAction.php
+++ b/Civi/Api4/Generic/DAOGetAction.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\Api4\Generic\Result;
-
 /**
  * Retrieve items based on criteria specified in the 'where' param.
  *

--- a/Civi/Api4/Generic/DAOUpdateAction.php
+++ b/Civi/Api4/Generic/DAOUpdateAction.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Api4\Generic;
 
-use Civi\Api4\Generic\Result;
-
 /**
  * Update one or more records with new values.
  *
@@ -52,6 +50,10 @@ class DAOUpdateAction extends AbstractUpdateAction {
     $items = $this->getObjects();
     foreach ($items as &$item) {
       $item = $this->values + $item;
+    }
+
+    if (!$items) {
+      throw new \API_Exception('Cannot ' . $this->getActionName() . ' ' . $this->getEntityName() . ', no records found with ' . $this->whereClauseToString());
     }
 
     $result->exchangeArray($this->writeObjects($items));

--- a/tests/phpunit/DataSets/ConformanceTest.json
+++ b/tests/phpunit/DataSets/ConformanceTest.json
@@ -3,7 +3,8 @@
     {
       "first_name": "Janice",
       "last_name": "Voss",
-      "contact_type": "Individual"
+      "contact_type": "Individual",
+      "@ref": "test_contact_1"
     }
   ],
   "CustomGroup": [
@@ -23,6 +24,13 @@
     {
       "name": "the_group",
       "title": "The Group"
+    }
+  ],
+  "Activity": [
+    {
+      "subject": "Test A Phone Activity",
+      "activity_type": "Phone Call",
+      "source_contact_id": "@ref test_contact_1.id"
     }
   ]
 }


### PR DESCRIPTION
I think this makes sense. We get an error from the DAO when trying to update an invalid record by id, so this is consistent.