### PR TITLE
Hide language field in explorer on single-lang sites

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -71,6 +71,10 @@ class GetActions extends BasicGetAction {
           }
           if ($this->_isFieldSelected('params')) {
             $this->_actions[$actionName]['params'] = $action->getParamInfo();
+            // Language param is only relevant on multilingual sites
+            if (count((array) \Civi::settings()->get('languageLimit')) < 2) {
+              unset($this->_actions[$actionName]['params']['language']);
+            }
           }
         }
       }


### PR DESCRIPTION
No need to advertise an irrelevant field.