### PR TITLE
Exclude test records from api Get by default

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/GetActionDefaultsProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/GetActionDefaultsProvider.php
@@ -10,9 +10,16 @@ class GetActionDefaultsProvider implements Generic\SpecProviderInterface {
    * @inheritDoc
    */
   public function modifySpec(RequestSpec $spec) {
+    // Exclude deleted records from api Get by default
     $isDeletedField = $spec->getFieldByName('is_deleted');
     if ($isDeletedField) {
       $isDeletedField->setDefaultValue('0');
+    }
+
+    // Exclude test records from api Get by default
+    $isTestField = $spec->getFieldByName('is_test');
+    if ($isTestField) {
+      $isTestField->setDefaultValue('0');
     }
   }
 

--- a/tests/phpunit/Entity/ParticipantTest.php
+++ b/tests/phpunit/Entity/ParticipantTest.php
@@ -207,17 +207,15 @@ class ParticipantTest extends UnitTestCase {
         ->execute();
     }
 
+    // By default is_test participants are hidden
+    $this->assertCount(0, Participant::get()->selectRowCount()->addWhere('event_id', '=', $secondEventId)->execute());
+
     // Test records show up if you add is_test to the query
-    $testParticipants = Participant::get()->addWhere('event_id', '=', $secondEventId)->addWhere('is_test', '=', 1)->execute();
+    $testParticipants = Participant::get()->addWhere('event_id', '=', $secondEventId)->addWhere('is_test', '=', 1)->addSelect('id')->execute();
     $this->assertCount($contactCount, $testParticipants);
 
     // Or if you search by id
-    $this->assertEquals(1, Participant::get()->selectRowCount()->addWhere('id', '=', $testParticipants->first()['id'])->execute()->count());
-
-    $this->markTestIncomplete('Not yet setting default for is_test field. See dev/core#1062.');
-
-    // By default is_test participants are hidden
-    $this->assertEmpty(Participant::get()->selectRowCount()->addWhere('event_id', '=', $secondEventId)->execute()->count());
+    $this->assertCount(1, Participant::get()->selectRowCount()->addWhere('id', '=', $testParticipants->first()['id'])->execute());
   }
 
 }


### PR DESCRIPTION
Sets a field default for all entities with an is_test field. This will cause them to be excluded by default from all api Get calls, unless the where clause specifies is_test or retrieves items by id.

Core entities with an is_test field:

- Activity
- Contribution
- ContributionRecur
- Participant
- PaymentProcessor
- MailingJob
- Membership
- Pledge