### PR TITLE
Let the BAO handle api_key permission checks

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -41,7 +41,7 @@ trait DAOActionTrait {
     foreach ($fields as $key => $field) {
       $name = $field['name'];
       if (property_exists($bao, $name)) {
-        $values[$name] = $bao->$name;
+        $values[$name] = isset($bao->$name) ? $bao->$name : NULL;
       }
     }
     return $values;
@@ -91,13 +91,6 @@ trait DAOActionTrait {
       $this->formatCustomParams($item, $entityId);
       $item['check_permissions'] = $this->getCheckPermissions();
 
-      $apiKeyPermission = $this->getEntityName() != 'Contact' || !$this->getCheckPermissions() || array_key_exists('api_key', $this->entityFields())
-        || ($entityId && \CRM_Core_Permission::check('edit own api keys') && \CRM_Core_Session::getLoggedInContactID() == $entityId);
-
-      if (!$apiKeyPermission && array_key_exists('api_key', $item)) {
-        throw new \Civi\API\Exception\UnauthorizedException('Permission denied to modify api key');
-      }
-
       // For some reason the contact bao requires this
       if ($entityId && $this->getEntityName() == 'Contact') {
         $item['contact_id'] = $entityId;
@@ -128,10 +121,6 @@ trait DAOActionTrait {
 
       // trim back the junk and just get the array:
       $resultArray = $this->baoToArray($createResult);
-
-      if (!$apiKeyPermission && array_key_exists('api_key', $resultArray)) {
-        unset($resultArray['api_key']);
-      }
 
       $result[] = $resultArray;
     }

--- a/tests/phpunit/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/Action/ContactApiKeyTest.php
@@ -64,7 +64,7 @@ class ContactApiKeyTest extends \Civi\Test\Api4\UnitTestCase {
   }
 
   public function testUpdateApiKey() {
-    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit all contacts'];
     $key = uniqid();
 
     $contact = Contact::create()
@@ -118,7 +118,7 @@ class ContactApiKeyTest extends \Civi\Test\Api4\UnitTestCase {
   }
 
   public function testUpdateOwnApiKey() {
-    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit own api keys', 'edit my contact'];
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit own api keys', 'edit all contacts'];
     $key = uniqid();
 
     $contact = Contact::create()


### PR DESCRIPTION
This is a followup to core PR https://github.com/civicrm/civicrm-core/pull/14660

Tests will fail until that PR is merged.
Core version should be bumped to match the version that gets merged into.