### PR TITLE
Ensure Abstract classes are not registered as services

### DIFF
--- a/api4.php
+++ b/api4.php
@@ -106,6 +106,11 @@ function _api4_load_services($namespace, $tag, $container) {
       $matches = [];
       preg_match('/(\w*).php/', $file, $matches);
       $serviceName = $namespace . array_pop($matches);
+      if (strpos($serviceName, '\Abstract') !== 0) {
+        // Do not register Civi\Api4\Event\Subscriber\AbstractPrepareSubscriber
+        // as it is an abstract class & cannot be loaded.
+        continue;
+      }
       $definition = $container->register(str_replace('\\', '_', $serviceName), $serviceName);
       $definition->addTag($tag);
     }


### PR DESCRIPTION
Addresses a bug I'm hitting....

Error: Cannot instantiate abstract class Civi\Api4\Event\Subscriber\AbstractPrepareSubscriber in CachedCiviContainer->getCiviApi4EventSubscriberAbstractpreparesubscriberService() (line 388 of /Users/eileenmcnaughton/buildkit/build/wmff/sites/default/files/civicrm/templates_c/CachedCiviContainer.4e127f05ef12b459462f1a07c98111f2.php).

What I can't figure out  is why this bug doesn't seem to always  occur - ie. I'm hitting it consistently on WMF sites but not all my local dev sites (despite them having the same civicrm code)