### PR TITLE
Breaking Change: n-to-1 joins output flat instead of nested

### DIFF
--- a/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
@@ -5,7 +5,6 @@ namespace Civi\Api4\Event\Subscriber;
 use Civi\Api4\Event\Events;
 use Civi\Api4\Event\PostSelectQueryEvent;
 use Civi\Api4\Query\Api4SelectQuery;
-use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Civi\Api4\Utils\ArrayInsertionUtil;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PostSelectQuerySubscriber.php
@@ -46,9 +46,9 @@ class PostSelectQuerySubscriber implements EventSubscriberInterface {
     $this->unserializeFields($results, $query->getEntity(), $fieldSpec);
 
     // Group the selects to avoid queries for each field
-    $groupedSelects = $this->getJoinedDotSelects($query);
+    $groupedSelects = $this->getNtoManyJoinSelects($query);
     foreach ($groupedSelects as $finalAlias => $selects) {
-      $joinPath = $this->getJoinPathInfo($selects[0], $query);
+      $joinPath = $query->getPathJoinTypes($selects[0]);
       $selects = $this->formatSelects($finalAlias, $selects, $query);
       $joinResults = $this->getJoinResults($query, $finalAlias, $selects);
       $this->formatJoinResults($joinResults, $query, $finalAlias);
@@ -92,11 +92,6 @@ class PostSelectQuerySubscriber implements EventSubscriberInterface {
    * @param array $fields
    */
   protected function unserializeFields(&$results, $entity, $fields = []) {
-    if (empty($fields)) {
-      $params = ['action' => 'get', 'includeCustom' => FALSE];
-      $fields = civicrm_api4($entity, 'getFields', $params)->indexBy('name');
-    }
-
     foreach ($results as &$result) {
       foreach ($result as $field => &$value) {
         if (!empty($fields[$field]['serialize']) && is_string($value)) {
@@ -108,17 +103,18 @@ class PostSelectQuerySubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Find only those joins that need to be handled by a separate query and weren't done in the main query.
+   *
    * @param \Civi\Api4\Query\Api4SelectQuery $query
    *
    * @return array
    */
-  private function getJoinedDotSelects(Api4SelectQuery $query) {
-    // Remove selects that are not in a joined table
+  private function getNtoManyJoinSelects(Api4SelectQuery $query) {
     $fkAliases = $query->getFkSelectAliases();
     $joinedDotSelects = array_filter(
       $query->getSelect(),
-      function ($select) use ($fkAliases) {
-        return isset($fkAliases[$select]);
+      function ($select) use ($fkAliases, $query) {
+        return isset($fkAliases[$select]) && array_filter($query->getPathJoinTypes($select));
       }
     );
 
@@ -287,38 +283,6 @@ class PostSelectQuerySubscriber implements EventSubscriberInterface {
     });
 
     return $joinResults;
-  }
-
-  /**
-   * Separates a string like 'emails.location_type.label' into an array, where
-   * each value in the array tells whether it is 1-1 or 1-n join type
-   *
-   * @param string $pathString
-   *   Dot separated path to the field
-   * @param \Civi\Api4\Query\Api4SelectQuery $query
-   *
-   * @return array
-   *   Index is table alias and value is boolean whether is 1-to-many join
-   */
-  private function getJoinPathInfo($pathString, $query) {
-    $pathParts = explode('.', $pathString);
-    // remove field
-    array_pop($pathParts);
-    $path = [];
-    $isMultipleChecker = function($alias) use ($query) {
-      foreach ($query->getJoinedTables() as $table) {
-        if ($table->getAlias() === $alias) {
-          return $table->getJoinType() === Joinable::JOIN_TYPE_ONE_TO_MANY;
-        }
-      }
-      return FALSE;
-    };
-
-    foreach ($pathParts as $part) {
-      $path[$part] = $isMultipleChecker($part);
-    }
-
-    return $path;
   }
 
   /**

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -14,8 +14,8 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
   /**
    * Criteria for selecting items to process.
    *
-   * @required
    * @var array
+   * @required
    */
   protected $where = [];
 

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -18,8 +18,8 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
   /**
    * Field values to update.
    *
-   * @required
    * @var array
+   * @required
    */
   protected $values = [];
 

--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -38,14 +38,14 @@ class SpecFormatter {
     if (!empty($data['custom_group_id'])) {
       $field = new CustomFieldSpec($data['name'], $entity, $dataTypeName);
       if (strpos($entity, 'Custom_') !== 0) {
-        $field->setName($data['custom_group']['name'] . '.' . $data['name']);
+        $field->setName($data['custom_group.name'] . '.' . $data['name']);
       }
       else {
-        $field->setCustomTableName($data['custom_group']['table_name']);
+        $field->setCustomTableName($data['custom_group.table_name']);
         $field->setCustomFieldColumnName($data['column_name']);
       }
       $field->setCustomFieldId(ArrayHelper::value('id', $data));
-      $field->setCustomGroupName($data['custom_group']['name']);
+      $field->setCustomGroupName($data['custom_group.name']);
       $field->setTitle(ArrayHelper::value('label', $data));
       $field->setOptions(self::customFieldHasOptions($data));
       if (\CRM_Core_BAO_CustomField::isSerialized($data)) {

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -45,7 +45,6 @@ class FormattingUtil {
       elseif (array_key_exists($name, $params) && $params[$name] === NULL) {
         $params[$name] = 'null';
       }
-
     }
   }
 
@@ -56,6 +55,8 @@ class FormattingUtil {
    *
    * @param $value
    * @param $fieldSpec
+   * @param string $entity
+   *   Ex: 'Contact', 'Domain'
    * @throws \API_Exception
    */
   public static function formatValue(&$value, $fieldSpec, $entity) {

--- a/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Action/BasicCustomFieldTest.php
@@ -46,10 +46,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertArrayHasKey('MyContactFields', $contact);
-    $contactFields = $contact['MyContactFields'];
-    $this->assertArrayHasKey('FavColor', $contactFields);
-    $this->assertEquals('Red', $contactFields['FavColor']);
+    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
 
     Contact::update()
       ->addWhere('id', '=', $contactId)
@@ -63,8 +60,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $contactFields = $contact['MyContactFields'];
-    $this->assertEquals('Blue', $contactFields['FavColor']);
+    $this->assertEquals('Blue', $contact['MyContactFields.FavColor']);
   }
 
   public function testWithTwoFields() {
@@ -121,10 +117,8 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertArrayHasKey('MyContactFields', $contact);
-    $contactFields = $contact['MyContactFields'];
-    $this->assertArrayHasKey('FavColor', $contactFields);
-    $this->assertEquals('Red', $contactFields['FavColor']);
+    $this->assertArrayHasKey('MyContactFields.FavColor', $contact);
+    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
 
     Contact::update()
       ->addWhere('id', '=', $contactId1)
@@ -138,8 +132,7 @@ class BasicCustomFieldTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $contactFields = $contact['MyContactFields'];
-    $this->assertEquals('Blue', $contactFields['FavColor']);
+    $this->assertEquals('Blue', $contact['MyContactFields.FavColor']);
 
     $search = Contact::get()
       ->setCheckPermissions(FALSE)

--- a/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
+++ b/tests/phpunit/api/v4/Action/ContactApiKeyTest.php
@@ -39,7 +39,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->addSelect('contact.api_key')
       ->addWhere('id', '=', $contact['email']['id'])
       ->execute()->first();
-    $this->assertEquals($key, $email['contact']['api_key']);
+    $this->assertEquals($key, $email['contact.api_key']);
 
     // Remove permission and we should not see the key
     \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
@@ -55,7 +55,7 @@ class ContactApiKeyTest extends \api\v4\UnitTestCase {
       ->addSelect('contact.api_key')
       ->addWhere('id', '=', $contact['email']['id'])
       ->execute()->first();
-    $this->assertTrue(empty($email['contact']['api_key']));
+    $this->assertTrue(empty($email['contact.api_key']));
 
     $result = Contact::get()
       ->addWhere('id', '=', $contact['id'])

--- a/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
+++ b/tests/phpunit/api/v4/Action/CreateWithOptionGroupTest.php
@@ -88,14 +88,9 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertArrayHasKey($group, $result);
-    $favoriteThings = $result[$group];
-    $favoriteFood = $favoriteThings[$foodField];
-    $favoriteColor = $favoriteThings[$colorField];
-    $financialStuff = $result['FinancialStuff'];
-    $this->assertEquals('Red', $favoriteColor['label']);
-    $this->assertEquals('Corn', $favoriteFood['label']);
-    $this->assertEquals(50000, $financialStuff['Salary']);
+    $this->assertEquals('Red', $result["$group.$colorField.label"]);
+    $this->assertEquals('Corn', $result["$group.$foodField.label"]);
+    $this->assertEquals(50000, $result['FinancialStuff.Salary']);
   }
 
   public function testWithCustomDataForMultipleContacts() {
@@ -182,9 +177,9 @@ class CreateWithOptionGroupTest extends BaseCustomValueTest {
       }
     }
 
-    $this->assertEquals('Blue', $blueCheese[$group][$colorField]['label']);
-    $this->assertEquals('Cheese', $blueCheese[$group][$foodField]['label']);
-    $this->assertEquals(500000, $blueCheese['FinancialStuff']['Salary']);
+    $this->assertEquals('Blue', $blueCheese["$group.$colorField.label"]);
+    $this->assertEquals('Cheese', $blueCheese["$group.$foodField.label"]);
+    $this->assertEquals(500000, $blueCheese['FinancialStuff.Salary']);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
@@ -46,7 +46,7 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertEquals('Red',  $contact['MyContactFields.FavColor']);
+    $this->assertEquals('Red', $contact['MyContactFields.FavColor']);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
+++ b/tests/phpunit/api/v4/Action/ExtendFromIndividualTest.php
@@ -46,10 +46,7 @@ class ExtendFromIndividualTest extends BaseCustomValueTest {
       ->execute()
       ->first();
 
-    $this->assertArrayHasKey('MyContactFields', $contact);
-    $contactFields = $contact['MyContactFields'];
-    $favColor = $contactFields['FavColor'];
-    $this->assertEquals('Red', $favColor);
+    $this->assertEquals('Red',  $contact['MyContactFields.FavColor']);
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -40,8 +40,8 @@ class ContactJoinTest extends UnitTestCase {
         'select' => ['contact.display_name', 'contact.id'],
       ]);
       foreach ($results as $result) {
-        $this->assertEquals($contact['id'], $result['contact']['id']);
-        $this->assertEquals($contact['display_name'], $result['contact']['display_name']);
+        $this->assertEquals($contact['id'], $result['contact.id']);
+        $this->assertEquals($contact['display_name'], $result['contact.display_name']);
       }
     }
   }

--- a/tests/phpunit/api/v4/Mock/MockV4ReflectionChild.php
+++ b/tests/phpunit/api/v4/Mock/MockV4ReflectionChild.php
@@ -8,6 +8,7 @@ namespace api\v4\Mock;
 class MockV4ReflectionChild extends MockV4ReflectionBase {
   /**
    * @var array
+   * @inheritDoc
    *
    * In the child class, foo has been barred.
    */

--- a/tests/phpunit/api/v4/Mock/MockV4ReflectionChild.php
+++ b/tests/phpunit/api/v4/Mock/MockV4ReflectionChild.php
@@ -7,7 +7,7 @@ namespace api\v4\Mock;
  */
 class MockV4ReflectionChild extends MockV4ReflectionBase {
   /**
-   * @inheritDoc
+   * @var array
    *
    * In the child class, foo has been barred.
    */

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -70,9 +70,7 @@ class Api4SelectQueryTest extends UnitTestCase {
 
     $this->assertCount(1, $results);
     $firstResult = array_shift($results);
-    $this->assertArrayHasKey('contact', $firstResult);
-    $resultContact = $firstResult['contact'];
-    $this->assertEquals($contact['display_name'], $resultContact['display_name']);
+    $this->assertEquals($contact['display_name'], $firstResult['contact.display_name']);
   }
 
   public function testOneToManyMultipleJoin() {

--- a/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
+++ b/tests/phpunit/api/v4/Query/OneToOneJoinTest.php
@@ -37,8 +37,8 @@ class OneToOneJoinTest extends UnitTestCase {
       ->indexBy('last_name')
       ->getArrayCopy();
 
-    $this->assertEquals($contacts['One']['preferred_language']['label'], 'Armenian');
-    $this->assertEquals($contacts['Two']['preferred_language']['label'], 'Basque');
+    $this->assertEquals($contacts['One']['preferred_language.label'], 'Armenian');
+    $this->assertEquals($contacts['Two']['preferred_language.label'], 'Basque');
   }
 
 }

--- a/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
+++ b/tests/phpunit/api/v4/Query/SelectQueryMultiJoinTest.php
@@ -62,7 +62,7 @@ class SelectQueryMultiJoinTest extends UnitTestCase {
     $secondContactEmailIds = [$thirdEmail['id'], $fourthEmail['id']];
 
     foreach ($results as $id => $email) {
-      $displayName = $email['contact']['display_name'];
+      $displayName = $email['contact.display_name'];
       if (in_array($id, $firstContactEmailIds)) {
         $this->assertEquals('First Contact', $displayName);
       }

--- a/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
+++ b/tests/phpunit/api/v4/Spec/SpecFormatterTest.php
@@ -44,7 +44,7 @@ class SpecFormatterTest extends UnitTestCase {
 
     $data = [
       'custom_group_id' => $customGroupId,
-      'custom_group' => ['name' => 'my_group'],
+      'custom_group.name' => 'my_group',
       'id' => $customFieldId,
       'name' => $name,
       'data_type' => 'String',


### PR DESCRIPTION
Overview
----------

This changes the signature of custom fields and other n-to-1 joins from nested to flat. Although this is a breaking change, it's going to solve a major headache in that the nested format caused the inputs and outputs of the api to be annoyingly different. Since they are single-valued anyway there is no reason to nest them, so this changes them back to a flat format like it was in api v3.

Before
----------

    "id": "5",
    "display_name": "Kandace Cruz",
    "contact_type": {
      "label": "Individual"
    },
    "constituent_information": {
      "Most_Important_Issue": "Edu",
      "Marital_Status": "M"
    },
    "addresses": [
      {
        "street_address": "594Q Van Ness Ave SW",
        "id": "87"
      }
    ]

After
------

    "id": "5",
    "display_name": "Kandace Cruz",
    "contact_type.label": "Individual",
    "constituent_information.Most_Important_Issue": "Edu",
    "constituent_information.Marital_Status": "M",
    "addresses": [
      {
        "street_address": "594Q Van Ness Ave SW",
        "id": "87"
      }
    ]
 