### PR TITLE
Avoid conflict during core 5.19 upgrade

### DIFF
--- a/api4.php
+++ b/api4.php
@@ -3,54 +3,58 @@
 require_once 'api4.civix.php';
 require_once 'api/Exception.php';
 
-/**
- * Procedural wrapper for the OO api version 4.
- *
- * @param string $entity
- * @param string $action
- * @param array $params
- * @param string|int $index
- *   If $index is a string, the results array will be indexed by that key.
- *   If $index is an integer, only the result at that index will be returned.
- *
- * @return \Civi\Api4\Generic\Result
- * @throws \API_Exception
- * @throws \Civi\API\Exception\NotImplementedException
- */
-function civicrm_api4($entity, $action, $params = [], $index = NULL) {
-  $apiCall = \Civi\Api4\Utils\ActionUtil::getAction($entity, $action);
-  foreach ($params as $name => $param) {
-    $setter = 'set' . ucfirst($name);
-    $apiCall->$setter($param);
-  }
-  $result = $apiCall->execute();
+if (!is_callable('civicrm_api4')) {
 
-  // Index results by key
-  if ($index && is_string($index) && !CRM_Utils_Rule::integer($index)) {
-    $result->indexBy($index);
-  }
-  // Return result at index
-  if (CRM_Utils_Rule::integer($index)) {
-    $item = $result->itemAt($index);
-    if (is_null($item)) {
-      throw new \API_Exception("Index $index not found in api results");
+    /**
+     * Procedural wrapper for the OO api version 4.
+     *
+     * @param string $entity
+     * @param string $action
+     * @param array $params
+     * @param string|int $index
+     *   If $index is a string, the results array will be indexed by that key.
+     *   If $index is an integer, only the result at that index will be returned.
+     *
+     * @return \Civi\Api4\Generic\Result
+     * @throws \API_Exception
+     * @throws \Civi\API\Exception\NotImplementedException
+     */
+  function civicrm_api4($entity, $action, $params = [], $index = NULL) {
+    $apiCall = \Civi\Api4\Utils\ActionUtil::getAction($entity, $action);
+    foreach ($params as $name => $param) {
+      $setter = 'set' . ucfirst($name);
+      $apiCall->$setter($param);
     }
-    // Attempt to return a Result object if item is array, otherwise just return the item
-    if (!is_array($item)) {
-      return $item;
+    $result = $apiCall->execute();
+
+    // Index results by key
+    if ($index && is_string($index) && !CRM_Utils_Rule::integer($index)) {
+      $result->indexBy($index);
     }
-    $result->exchangeArray($item);
+    // Return result at index
+    if (CRM_Utils_Rule::integer($index)) {
+      $item = $result->itemAt($index);
+      if (is_null($item)) {
+        throw new \API_Exception("Index $index not found in api results");
+      }
+      // Attempt to return a Result object if item is array, otherwise just return the item
+      if (!is_array($item)) {
+        return $item;
+      }
+      $result->exchangeArray($item);
 
+    }
+    return $result;
   }
-  return $result;
-}
 
-/**
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
- */
-function api4_civicrm_container($container) {
-  require_once __DIR__ . '/CRM/Api4/Services.php';
-  CRM_Api4_Services::hook_container($container);
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   */
+  function api4_civicrm_container($container) {
+    require_once __DIR__ . '/CRM/Api4/Services.php';
+    CRM_Api4_Services::hook_container($container);
+  }
+
 }
 
 /**


### PR DESCRIPTION
Overview
---------

These globals should only be loaded conditionally to avoid a php fatal when upgrading to a version of civicrm-core with api4 built in.

Before
-------

When upgrading to 5.19 with Api4 extension already enabled, you get `PHP Fatal error:  Cannot redeclare civicrm_api4()`.

After
-------

Upgrade proceeds to disable the extension with no conflicts.